### PR TITLE
Don't warn on case sensitive command options labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.2
+
+- Don't raise label clashing warnings for options which only differ between upper and lower case
+
 ## 1.8.1
 
 - Fix reference clashing for options which only differ between upper and lower case

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -30,6 +30,7 @@ from docutils.nodes import (
     section,
     strong,
     title,
+    whitespace_normalize_name,
 )
 from docutils.parsers.rst.directives import (  # type: ignore # no stubs
     positive_int,
@@ -229,15 +230,16 @@ class SphinxArgparseCli(SphinxDirective):
         st = strong()
         st += literal(text=opt)
         ref += st
-        self._register_ref(ref_id, ref_title, ref)
+        self._register_ref(ref_id, ref_title, ref, is_cli_option=True)
         line += ref
 
-    def _register_ref(self, ref_name: str, ref_title: str, node: Element) -> None:
+    def _register_ref(self, ref_name: str, ref_title: str, node: Element, is_cli_option: bool = False) -> None:
         doc_name = self.env.docname
+        normalize_name = whitespace_normalize_name if is_cli_option else fully_normalize_name
         if self.env.config.sphinx_argparse_cli_prefix_document:
-            name = fully_normalize_name(f"{doc_name}:{ref_name}")
+            name = normalize_name(f"{doc_name}:{ref_name}")
         else:
-            name = fully_normalize_name(ref_name)
+            name = normalize_name(ref_name)
         if name in self._std_domain.labels:
             logger.warning(
                 __("duplicate label %s, other instance in %s"),

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -210,6 +210,7 @@ def test_store_true_false(build_outcome: str) -> None:
 
 
 @pytest.mark.sphinx(buildername="html", testroot="lower-upper-refs")
-def test_lower_upper_refs(build_outcome: str) -> None:
+def test_lower_upper_refs(build_outcome: str, warning: StringIO) -> None:
     assert '<p id="basic--d"><a class="reference internal" href="#basic--d" title="basic -d">' in build_outcome
     assert '<p id="basic--D"><a class="reference internal" href="#basic--D" title="basic -D">' in build_outcome
+    assert not warning.getvalue()


### PR DESCRIPTION
It seems that the patch in #32 was not complete. I'm getting `WARNING: duplicate label md2po--d, other instance...` building _mdpo_ documentation.

This patch is to avoid to raise warnings for case sensitive command options.