### PR TITLE
Add option to hook argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Within the reStructuredText files use the `sphinx_argparse_cli` directive that t
 | module                 | the module path to where the parser is defined                                                                                                                                   |
 | func                   | the name of the function that once called with no arguments constructs the parser                                                                                                |
 | prog                   | (optional) the module path to where the parser is defined                                                                                                                        |
+| hook                   | (optional) hook `argparse` to retrieve the parser if `func` uses a parser instead of returning it.                                                                               |
 | title                  | (optional) when provided, overwrites the `<prog> - CLI interface` title added by default and when empty, will not be included                                                    |
 | usage_width            | (optional) how large should usage examples be - defaults to 100 character                                                                                                        |
 | group_title_prefix     | (optional) groups subsections title prefixes, accepts the string `{prog}` as a replacement for the program name - defaults to `{prog}`                                           |
@@ -45,6 +46,16 @@ For example:
 .. sphinx_argparse_cli::
   :module: a_project.cli
   :func: build_parser
+  :prog: my-cli-program
+```
+
+If you have code that creates and uses a parser but does not return it, you can specify the `:hook:` flag:
+
+```rst
+.. sphinx_argparse_cli::
+  :module: a_project.cli
+  :func: main
+  :hook:
   :prog: my-cli-program
 ```
 

--- a/roots/test-hook-fail/conf.py
+++ b/roots/test-hook-fail/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-hook-fail/index.rst
+++ b/roots/test-hook-fail/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: main
+  :hook:

--- a/roots/test-hook-fail/parser.py
+++ b/roots/test-hook-fail/parser.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def main() -> None:
+    parser = ArgumentParser(prog="foo", add_help=False)
+    print(parser)

--- a/roots/test-hook/conf.py
+++ b/roots/test-hook/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-hook/index.rst
+++ b/roots/test-hook/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: main
+  :hook:

--- a/roots/test-hook/parser.py
+++ b/roots/test-hook/parser.py
@@ -6,3 +6,4 @@ from argparse import ArgumentParser
 def main() -> None:
     parser = ArgumentParser(prog="foo", add_help=False)
     args = parser.parse_args()
+    print(args)

--- a/roots/test-hook/parser.py
+++ b/roots/test-hook/parser.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def main() -> None:
+    parser = ArgumentParser(prog="foo", add_help=False)
+    args = parser.parse_args()

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -97,8 +97,8 @@ class SphinxArgparseCli(SphinxDirective):
                 ArgumentParser.parse_known_args = _argparse_parse_known_args_hook  # type: ignore
                 try:
                     parser_creator()
-                except HookExit as exc:
-                    self._parser = exc.parser
+                except HookError as hooked:
+                    self._parser = hooked.parser
                 finally:
                     ArgumentParser.parse_known_args = original_parse_known_args  # type: ignore
 
@@ -338,13 +338,13 @@ def load_help_text(help_text: str) -> str:
     return literal_curly_braces
 
 
-class HookExit(Exception):
+class HookError(Exception):
     def __init__(self, parser: ArgumentParser):
         self.parser = parser
 
 
-def _argparse_parse_known_args_hook(self: ArgumentParser, *args: Any, **kwargs: Any) -> None:
-    raise HookExit(self)
+def _argparse_parse_known_args_hook(self: ArgumentParser, *args: Any, **kwargs: Any) -> None:  # noqa: U100
+    raise HookError(self)
 
 
 __all__ = ("SphinxArgparseCli",)

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -101,14 +101,15 @@ class SphinxArgparseCli(SphinxDirective):
                     self._parser = hooked.parser
                 finally:
                     ArgumentParser.parse_known_args = original_parse_known_args  # type: ignore
-
-                if self._parser is None:
-                    raise Exception("Failed to hook argparse to get ArgumentParser")
             else:
                 self._parser = parser_creator()
+
+            del sys.modules[module_name]  # no longer needed cleanup
+            if self._parser is None:
+                raise self.error("Failed to hook argparse to get ArgumentParser")
+
             if "prog" in self.options:
                 self._parser.prog = self.options["prog"]
-            del sys.modules[module_name]  # no longer needed cleanup
         return self._parser
 
     def load_sub_parsers(self) -> Iterator[tuple[list[str], str, ArgumentParser]]:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -63,10 +63,12 @@ def test_hook(build_outcome: str) -> None:
     assert build_outcome
 
 
-@pytest.mark.sphinx(buildername="html", testroot="hook-fail")
+@pytest.mark.sphinx(buildername="text", testroot="hook-fail")
 def test_hook_fail(app: SphinxTestApp) -> None:
     app.build()
-    assert app._warncount == 1
+    text = (Path(app.outdir) / "index.txt").read_text()
+    assert "Failed to hook argparse to get ArgumentParser" in app._warning.getvalue()
+    assert text == ""
 
 
 @pytest.mark.sphinx(buildername="text", testroot="prog")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -63,6 +63,12 @@ def test_hook(build_outcome: str) -> None:
     assert build_outcome
 
 
+@pytest.mark.sphinx(buildername="html", testroot="hook-fail")
+def test_hook_fail(app: SphinxTestApp) -> None:
+    app.build()
+    assert app._warncount == 1
+
+
 @pytest.mark.sphinx(buildername="text", testroot="prog")
 def test_prog_as_text(build_outcome: str) -> None:
     assert build_outcome == "magic - CLI interface\n*********************\n\n   magic\n"

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -64,10 +64,10 @@ def test_hook(build_outcome: str) -> None:
 
 
 @pytest.mark.sphinx(buildername="text", testroot="hook-fail")
-def test_hook_fail(app: SphinxTestApp) -> None:
+def test_hook_fail(app: SphinxTestApp, warning: StringIO) -> None:
     app.build()
     text = (Path(app.outdir) / "index.txt").read_text()
-    assert "Failed to hook argparse to get ArgumentParser" in app._warning.getvalue()
+    assert "Failed to hook argparse to get ArgumentParser" in warning.getvalue()
     assert text == ""
 
 
@@ -137,14 +137,10 @@ def test_ref_prefix_doc(build_outcome: str) -> None:
     assert ref in build_outcome
 
 
-_REF_WARNING_STRING_IO = StringIO()  # could not find any better way to get the warning
-
-
-@pytest.mark.sphinx(buildername="text", testroot="ref-duplicate-label", warning=_REF_WARNING_STRING_IO)
-def test_ref_duplicate_label(build_outcome: tuple[str, str]) -> None:
+@pytest.mark.sphinx(buildername="text", testroot="ref-duplicate-label")
+def test_ref_duplicate_label(build_outcome: tuple[str, str], warning: StringIO) -> None:
     assert build_outcome
-    warnings = _REF_WARNING_STRING_IO.getvalue()
-    assert "duplicate label prog---help" in warnings
+    assert "duplicate label prog---help" in warning.getvalue()
 
 
 @pytest.mark.sphinx(buildername="html", testroot="group-title-prefix-default")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -58,6 +58,11 @@ def test_complex_as_html(build_outcome: str) -> None:
     assert build_outcome
 
 
+@pytest.mark.sphinx(buildername="html", testroot="hook")
+def test_hook(build_outcome: str) -> None:
+    assert build_outcome
+
+
 @pytest.mark.sphinx(buildername="text", testroot="prog")
 def test_prog_as_text(build_outcome: str) -> None:
     assert build_outcome == "magic - CLI interface\n*********************\n\n   magic\n"


### PR DESCRIPTION
Adds the option to hook argparse instead of having a function that returns an `ArgumentParser`.

My project has a lot of CLI utilities in the form of:
```python
def main():
    parser = argparse.ArgumentParser()
    # ... add arguments
    args = parser.parse_args()
```

I really like the functionality this extension provides, so I wanted to use it on that project. However I didn't want to change everything to be in the format this project requires. 

Hooking argparse should be perfectly safe within the context of this extension, so with this change you can now also use this extension on CLI scripts that have the format shown above.