### PR TITLE
Fix tox not running on CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Pick environment to run
         run: |
           import codecs; import os; import sys
-          env = f"TOXENV=py3{sys.version_info[0]}\n"
+          env = f"TOXENV=py3{sys.version_info[1]}\n"
           print("Picked:\n{env}for{sys.version}")
           with codecs.open(os.environ["GITHUB_ENV"], "a", "utf-8") as file_handler:
                file_handler.write(env)


### PR DESCRIPTION
The environment is always `py33` and [an error message](https://github.com/tox-dev/sphinx-argparse-cli/actions/runs/3130934448/jobs/5081733037#step:7:223) appears in the logs, but doesn't crashes.