### PR TITLE
Apply multiline handling to group description

### DIFF
--- a/roots/test-description-multiline/parser.py
+++ b/roots/test-description-multiline/parser.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 
 def make() -> ArgumentParser:
-    return ArgumentParser(
+    parser = ArgumentParser(
         prog="foo",
         description="""This description
 spans multiple lines.
@@ -17,3 +17,11 @@ Now this should be a separate paragraph.
         formatter_class=RawDescriptionHelpFormatter,
         add_help=False,
     )
+    group = parser.add_argument_group(
+        description="""This group description
+
+spans multiple lines.
+"""
+    )
+    group.add_argument("--dummy")
+    return parser

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -194,8 +194,8 @@ class SphinxArgparseCli(SphinxDirective):
         # the text sadly needs to be prefixed, because otherwise the autosectionlabel will conflict
         header = title("", Text(title_text))
         group_section = section("", header, ids=[ref_id], names=[ref_id])
-        if group.description:
-            group_section += paragraph("", Text(group.description))
+        if description := self._pre_format(group.description):
+            group_section += description
         self._register_ref(ref_id, title_text, group_section)
         opt_group = bullet_list()
         for action in group._group_actions:  # noqa: SLF001

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -107,6 +107,10 @@ def test_multiline_description_as_html(build_outcome: str) -> None:
     )
     assert ref in build_outcome
 
+    print(build_outcome)
+    ref = "This group description\n\nspans multiple lines.\n"
+    assert ref in build_outcome
+
 
 @pytest.mark.sphinx(buildername="text", testroot="epilog-set")
 def test_set_epilog_as_text(build_outcome: str) -> None:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -107,7 +107,6 @@ def test_multiline_description_as_html(build_outcome: str) -> None:
     )
     assert ref in build_outcome
 
-    print(build_outcome)
     ref = "This group description\n\nspans multiple lines.\n"
     assert ref in build_outcome
 


### PR DESCRIPTION
Fixes https://github.com/tox-dev/sphinx-argparse-cli/issues/151