### PR TITLE
Declare extension safe for parallel reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Allow to add content to directive.
+- Fix Sphinx warnings about parallel reads.
 
 ## 1.13.1
 

--- a/src/sphinx_argparse_cli/__init__.py
+++ b/src/sphinx_argparse_cli/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .version import __version__
 
@@ -10,13 +10,15 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx) -> dict[str, Any]:
     app.add_css_file("custom.css")
 
     from ._logic import SphinxArgparseCli
 
     app.add_directive(SphinxArgparseCli.name, SphinxArgparseCli)
     app.add_config_value("sphinx_argparse_cli_prefix_document", False, "env")  # noqa: FBT003
+
+    return {"parallel_read_safe": True}
 
 
 __all__ = [


### PR DESCRIPTION
This PR should fix the following Sphinx warning and make the extension faster.

```
WARNING: the sphinx_argparse_cli extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```

This commit is essentially the same as https://github.com/tox-dev/sphinx-autodoc-typehints/issues/9 / [c4657bc57a290a79605ed86398db28419aabfbb9](https://github.com/agronholm/sphinx-autodoc-typehints/commit/c4657bc57a290a79605ed86398db28419aabfbb9).