### PR TITLE
Handle nested subparsers

### DIFF
--- a/roots/test-subparsers/conf.py
+++ b/roots/test-subparsers/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-subparsers/index.rst
+++ b/roots/test-subparsers/index.rst
@@ -1,0 +1,3 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make

--- a/roots/test-subparsers/parser.py
+++ b/roots/test-subparsers/parser.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(prog="test")
+
+    sub_parsers = parser.add_subparsers()
+    sub_parser = sub_parsers.add_parser("subparser")
+    sub_parser.add_argument("--foo")
+
+    sub_parser_no_child = sub_parsers.add_parser("no_child")
+    sub_parser_no_child.add_argument("argument_one", help="no_child argument")
+
+    sub_sub_parsers = sub_parser.add_subparsers()
+    sub_sub_parser = sub_sub_parsers.add_parser("child_two")
+
+    sub_sub_sub_parsers = sub_sub_parser.add_subparsers()
+    sub_sub_sub_parser = sub_sub_sub_parsers.add_parser("child_three")
+    sub_sub_sub_parser.add_argument("argument", help="sub sub sub child pos argument")
+    sub_sub_sub_parser.add_argument("--flag", help="sub sub sub child argument")
+
+    return parser

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -331,3 +331,18 @@ def test_nested_content(build_outcome: str) -> None:
     assert "<h3>basic-2 opt" in build_outcome
     assert "<p>Some text inside second directive.</p>" in build_outcome
     assert "<p>Some text after directives.</p>" in build_outcome
+
+
+@pytest.mark.sphinx(buildername="html", testroot="subparsers")
+def test_subparsers(build_outcome: str) -> None:
+    assert '<section id="test-options">' in build_outcome
+    assert '<section id="test-subparser">' in build_outcome
+    assert '<section id="test-subparser-options">' in build_outcome
+    assert '<section id="test-subparser-child_two">' in build_outcome
+    assert '<section id="test-subparser-child_two-options">' in build_outcome
+    assert '<section id="test-subparser-child_two-child_three">' in build_outcome
+    assert '<section id="test-subparser-child_two-child_three-positional-arguments">' in build_outcome
+    assert '<section id="test-subparser-child_two-child_three-options">' in build_outcome
+    assert '<section id="test-no_child">' in build_outcome
+    assert '<section id="test-no_child-positional-arguments">' in build_outcome
+    assert '<section id="test-no_child-options">' in build_outcome


### PR DESCRIPTION
This handles outputting for nested sub-parsers.

First we modify the load_sub_parsers iterator to check if any of the arguments are subparsers, and if so, recurse into that subparser and yield its values back too.  (I am as skeptical of yielding from recursive generator functions as anyone :) If you have hundreds of levels of nested subparsers I guess this blows up ... but that seems impractical).

In _mk_sub_command, avoid adding subparsers so they don't show up as positional arguments (their Action has action.dest of "==SUPPRESS==" which looks wrong and they don't show up in cmd line help).  The subparsers are listed in the usage-string, e.g.

  test subparser [-h] [--foo FOO] {child_two} ...

In _build_opt_grp_title we are taking elements[:2] as the title text for the option group.  This ends up cutting off the full title when you have nested subparsers.  I have to admit I can't really determine why this is done, but it does not seem to affect any of the test cases and the output looks correct to me for nested subparsers, with the full command listed as the option title.