### PR TITLE
🐛 fix(metavar): render all tuple metavar elements and suppress None defaults

### DIFF
--- a/roots/test-tuple-metavar/conf.py
+++ b/roots/test-tuple-metavar/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-tuple-metavar/index.rst
+++ b/roots/test-tuple-metavar/index.rst
@@ -1,0 +1,3 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make

--- a/roots/test-tuple-metavar/parser.py
+++ b/roots/test-tuple-metavar/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(prog="tool")
+    parser.add_argument("--pair", nargs=2, metavar=("A", "B"), help="select a pair")
+    parser.add_argument("--val", metavar="VAL", help="single val")
+    return parser

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -268,7 +268,12 @@ class SphinxArgparseCli(SphinxDirective):
                 self._mk_option_name(line, prefix, opt)
                 if not is_flag:
                     line += Text(" ")
-                    line += literal(text=as_key.upper())
+                    metavar_text = (
+                        " ".join(meta.upper() for meta in action.metavar)
+                        if isinstance(action.metavar, tuple)
+                        else as_key.upper()
+                    )
+                    line += literal(text=metavar_text)
         else:
             self._mk_option_name(line, prefix, as_key)
 
@@ -282,6 +287,7 @@ class SphinxArgparseCli(SphinxDirective):
                 line += content
         if (
             "no_default_values" not in self.options
+            and action.default is not None
             and action.default != SUPPRESS
             and not re.match(r".*[ (]default[s]? .*", (action.help or ""))
             and not isinstance(action, _StoreTrueAction | _StoreFalseAction)

--- a/tests/complex.txt
+++ b/tests/complex.txt
@@ -17,10 +17,8 @@ complex options
 * **"--no-help"**
 
 * **"--outdir"** "OUT_DIR", **"-o"** "OUT_DIR" - output directory
-  (default: "None")
 
 * **"--in-dir"** "IN_DIR", **"-i"** "IN_DIR" - input directory
-  (default: "None")
 
 
 complex Exclusive
@@ -44,7 +42,7 @@ a-first-desc
 complex first positional arguments
 ----------------------------------
 
-* **"one"** - first positional argument (default: "None")
+* **"one"** - first positional argument
 
 * **"pos_two"** - second positional argument (default: "1")
 
@@ -68,7 +66,7 @@ complex second
 complex second positional arguments
 -----------------------------------
 
-* **"one"** - first positional argument (default: "None")
+* **"one"** - first positional argument
 
 * **"pos_two"** - second positional argument (default: "green")
 

--- a/tests/complex_pre_310.txt
+++ b/tests/complex_pre_310.txt
@@ -17,10 +17,8 @@ complex optional arguments
 * **"--no-help"**
 
 * **"--outdir"** "OUT_DIR", **"-o"** "OUT_DIR" - output directory
-  (default: "None")
 
 * **"--in-dir"** "IN_DIR", **"-i"** "IN_DIR" - input directory
-  (default: "None")
 
 
 complex Exclusive
@@ -44,7 +42,7 @@ a-first-desc
 complex first positional arguments
 ----------------------------------
 
-* **"one"** - first positional argument (default: "None")
+* **"one"** - first positional argument
 
 * **"pos_two"** - second positional argument (default: "1")
 
@@ -68,7 +66,7 @@ complex second
 complex second positional arguments
 -----------------------------------
 
-* **"one"** - first positional argument (default: "None")
+* **"one"** - first positional argument
 
 * **"pos_two"** - second positional argument (default: "green")
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -366,8 +366,9 @@ def test_nargs(build_outcome: str) -> None:
     assert "pos_optional" in build_outcome
     assert "pos_zero_or_more" in build_outcome
     assert "pos_one_or_more" in build_outcome
-    assert "KEY" in build_outcome
-    assert "VALUE" in build_outcome
+    assert "KEY VALUE" in build_outcome
+    assert "(default: " in build_outcome  # default_val is not None, should show
+    assert 'default: "None"' not in build_outcome
 
 
 @pytest.mark.sphinx(buildername="text", testroot="choices")
@@ -381,3 +382,11 @@ def test_actions(build_outcome: str) -> None:
     assert "increase verbosity" in build_outcome
     assert "paths to include" in build_outcome
     assert "a required optional argument" in build_outcome
+
+
+@pytest.mark.sphinx(buildername="text", testroot="tuple-metavar")
+def test_tuple_metavar(build_outcome: str) -> None:
+    assert '"A B"' in build_outcome or "A B" in build_outcome
+    assert "select a pair" in build_outcome
+    assert "default: None" not in build_outcome
+    assert '"VAL"' in build_outcome


### PR DESCRIPTION
Tuple metavars (e.g. `nargs=2` with `metavar=("KEY", "VALUE")`) only rendered the first element, making the documentation misleading for multi-value arguments. Now all elements are joined with spaces so the full signature is visible.

Additionally, arguments with `default=None` no longer display `(default: "None")` in the output. The string `"None"` added no useful information and was confusing — users couldn't tell if `None` was a real default or just Python's representation of no default.

Fixes #159, fixes #177