### PR TITLE
🐛 fix(prog): propagate :prog: override to subcommands

### DIFF
--- a/roots/test-prog-subcommands/conf.py
+++ b/roots/test-prog-subcommands/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-prog-subcommands/index.rst
+++ b/roots/test-prog-subcommands/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :prog: my-tool

--- a/roots/test-prog-subcommands/parser.py
+++ b/roots/test-prog-subcommands/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(prog="original-name")
+    sub = parser.add_subparsers()
+    sub.add_parser("foo", help="foo help")
+    return parser

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -390,3 +390,10 @@ def test_tuple_metavar(build_outcome: str) -> None:
     assert "select a pair" in build_outcome
     assert "default: None" not in build_outcome
     assert '"VAL"' in build_outcome
+
+
+@pytest.mark.sphinx(buildername="text", testroot="prog-subcommands")
+def test_prog_subcommands(build_outcome: str) -> None:
+    assert "my-tool" in build_outcome
+    assert "original-name" not in build_outcome
+    assert "my-tool foo" in build_outcome


### PR DESCRIPTION
When using the `:prog:` directive option to rename the program, only the top-level parser's `prog` was updated. Subcommand parsers still retained the original prog value, producing inconsistent section titles and cross-references in the generated documentation.

The fix recursively walks all subparser trees via `_update_sub_parser_prog` and replaces the old prog prefix with the new one. This ensures that titles like `my-tool foo` appear correctly instead of `original-name foo`.

Fixes #71