### PR TITLE
🐛 fix(titles): handle multi-word prog names in group titles

### DIFF
--- a/roots/test-multiword-prog/conf.py
+++ b/roots/test-multiword-prog/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-multiword-prog/index.rst
+++ b/roots/test-multiword-prog/index.rst
@@ -1,0 +1,3 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make

--- a/roots/test-multiword-prog/parser.py
+++ b/roots/test-multiword-prog/parser.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(prog="python -m build")
+    parser.add_argument("srcdir", help="source directory")
+    return parser

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -397,3 +397,9 @@ def test_prog_subcommands(build_outcome: str) -> None:
     assert "my-tool" in build_outcome
     assert "original-name" not in build_outcome
     assert "my-tool foo" in build_outcome
+
+
+@pytest.mark.sphinx(buildername="text", testroot="multiword-prog")
+def test_multiword_prog(build_outcome: str) -> None:
+    assert "python -m build positional arguments" in build_outcome
+    assert "python -m build options" in build_outcome


### PR DESCRIPTION
Programs with spaces in their `prog` (e.g. `python -m build`) had their section titles and group headings corrupted. 🐛 The title-building logic naively split `prog` on whitespace to separate the program name from subcommand names, so `python -m build` was interpreted as prog=`python` with subcommand `-m` — producing nonsensical headings.

The fix threads the actual root `prog` value through the title-building methods and uses its length to correctly locate the subcommand portion, rather than assuming `prog` is always a single word. This preserves existing behavior for single-word programs while correctly handling multi-word ones like `python -m build`.

Fixes #68