### PR TITLE
🐛 fix(setup): remove hard-coded custom.css reference

### DIFF
--- a/src/sphinx_argparse_cli/__init__.py
+++ b/src/sphinx_argparse_cli/__init__.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 
 def setup(app: Sphinx) -> dict[str, Any]:
-    app.add_css_file("custom.css")
-
     from ._logic import SphinxArgparseCli  # noqa: PLC0415
 
     app.add_directive(SphinxArgparseCli.name, SphinxArgparseCli)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -49,6 +49,7 @@ def build_outcome(app: SphinxTestApp, request: SubRequest, monkeypatch: pytest.M
 @pytest.mark.sphinx(buildername="html", testroot="basic")
 def test_basic_as_html(build_outcome: str) -> None:
     assert build_outcome
+    assert "custom.css" not in build_outcome
 
 
 @pytest.mark.sphinx(buildername="text", testroot="complex")


### PR DESCRIPTION
The extension unconditionally registered a `custom.css` stylesheet via `app.add_css_file("custom.css")`, but never provided the file itself. 🐛 This caused 404 errors in the browser console for any theme that doesn't happen to ship its own `custom.css` — which includes popular themes like `sphinx_rtd_theme` and `sphinx_immaterial`.

The fix removes the line entirely. The extension has no custom styles to inject, so the call served no purpose.

Fixes #82