### PR TITLE
🐛 fix(toctree): crash with empty title in toctree

### DIFF
--- a/roots/test-title-empty-groups/cli.rst
+++ b/roots/test-title-empty-groups/cli.rst
@@ -1,0 +1,7 @@
+CLI
+===
+
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make
+  :title:

--- a/roots/test-title-empty-groups/index.rst
+++ b/roots/test-title-empty-groups/index.rst
@@ -1,4 +1,10 @@
-.. sphinx_argparse_cli::
-  :module: parser
-  :func: make
-  :title:
+Overview
+========
+
+.. toctree::
+   :hidden:
+
+   self
+   cli
+
+See :doc:`cli` for details.

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -25,6 +25,7 @@ from docutils.nodes import (
     Node,
     Text,
     bullet_list,
+    container,
     fully_normalize_name,
     list_item,
     literal,
@@ -187,7 +188,7 @@ class SphinxArgparseCli(SphinxDirective):
         self.env.note_reread()  # this document needs to be always updated
         title_text = self.options.get("title", f"{self.parser.prog} - CLI interface").strip()
         if not title_text:
-            home_section: Element = section("")
+            home_section: Element = container("")
         else:
             home_section = section("", title("", Text(title_text)), ids=[self.make_id(title_text)], names=[title_text])
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -407,6 +407,10 @@ def test_multiword_prog(build_outcome: str) -> None:
 
 
 @pytest.mark.sphinx(buildername="html", testroot="title-empty-groups")
-def test_empty_title_groups_in_toctree(build_outcome: str) -> None:
-    assert '<section id="tool-options">' in build_outcome
-    assert "be verbose" in build_outcome
+def test_empty_title_groups_in_toctree(app: SphinxTestApp, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    app.build()
+    cli_html = (Path(app.outdir) / "cli.html").read_text()
+    assert '<section id="tool-options">' in cli_html
+    assert "be verbose" in cli_html


### PR DESCRIPTION
When a page using `:title:` (empty) is included in a toctree, Sphinx's `TocTreeCollector.process_doc` crashes with `list index out of range`. This breaks documentation builds for projects like pyproject-fmt that place the CLI directive on a separate page referenced from a toctree.

The previous fix (2e8609c) changed `paragraph()` to `section("")`, but a `section` node without a title child still triggers the crash because the toctree collector expects all sections to have a title as their first child. Using `container("")` instead avoids this entirely — containers are generic block-level grouping elements that don't participate in document sectioning, so the toctree collector simply ignores them.

The test now mirrors the real-world scenario: the directive lives on a separate `cli.rst` page that is included via `.. toctree::` from `index.rst`, which is the exact structure that triggers the bug.