### PR TITLE
🐛 fix(render): handle formatter subclasses and wrap preformatted blocks

### DIFF
--- a/roots/test-epilog-multiline-subclass/conf.py
+++ b/roots/test-epilog-multiline-subclass/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-epilog-multiline-subclass/index.rst
+++ b/roots/test-epilog-multiline-subclass/index.rst
@@ -1,0 +1,3 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make

--- a/roots/test-epilog-multiline-subclass/parser.py
+++ b/roots/test-epilog-multiline-subclass/parser.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, RawDescriptionHelpFormatter
+
+
+class _Formatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter): ...
+
+
+def make() -> ArgumentParser:
+    return ArgumentParser(
+        prog="foo",
+        epilog="""This epilog
+spans multiple lines.
+
+  this line is indented.
+    and also this.
+
+Now this should be a separate paragraph.
+""",
+        formatter_class=_Formatter,
+        add_help=False,
+    )

--- a/src/sphinx_argparse_cli/__init__.py
+++ b/src/sphinx_argparse_cli/__init__.py
@@ -15,8 +15,22 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.add_directive(SphinxArgparseCli.name, SphinxArgparseCli)
     app.add_config_value("sphinx_argparse_cli_prefix_document", False, "env")  # noqa: FBT003
+    app.add_css_file("sphinx_argparse_cli.css")
+    app.connect("build-finished", _write_css)
 
     return {"parallel_read_safe": True}
+
+
+def _write_css(app: Sphinx, exception: Exception | None) -> None:
+    if exception or not app.builder or app.builder.format != "html":
+        return
+    from pathlib import Path  # noqa: PLC0415
+
+    static = Path(app.outdir) / "_static"
+    static.mkdir(parents=True, exist_ok=True)
+    (static / "sphinx_argparse_cli.css").write_text(
+        ".sphinx-argparse-cli-wrap pre { white-space: pre-wrap; word-wrap: break-word; }\n"
+    )
 
 
 __all__ = [

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -145,7 +145,8 @@ class SphinxArgparseCli(SphinxDirective):
                 self._parser.prog = new_prog
                 _update_sub_parser_prog(self._parser, old_prog, new_prog)
 
-            self._raw_format = self._parser.formatter_class == RawDescriptionHelpFormatter
+            formatter = self._parser.formatter_class
+            self._raw_format = isinstance(formatter, type) and issubclass(formatter, RawDescriptionHelpFormatter)
         return self._parser
 
     def _load_sub_parsers(
@@ -224,7 +225,7 @@ class SphinxArgparseCli(SphinxDirective):
         if block is None:
             return None
         if self._raw_format and "\n" in block:
-            lit = literal_block("", Text(block))
+            lit = literal_block("", Text(block), classes=["sphinx-argparse-cli-wrap"])
             lit["language"] = "none"
             return lit
         return paragraph("", Text(block))
@@ -424,7 +425,7 @@ class SphinxArgparseCli(SphinxDirective):
         with self.no_color():
             texts = parser.format_usage()[len("usage: ") :].splitlines()
         texts = [line if at == 0 else f"{' ' * (len(parser.prog) + 1)}{line.lstrip()}" for at, line in enumerate(texts)]
-        return literal_block("", Text("\n".join(texts)))
+        return literal_block("", Text("\n".join(texts)), classes=["sphinx-argparse-cli-wrap"])
 
     @contextmanager
     def no_color(self) -> Iterator[None]:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -133,6 +133,15 @@ def test_multiline_epilog_as_html(build_outcome: str) -> None:
     assert ref in build_outcome
 
 
+@pytest.mark.sphinx(buildername="html", testroot="epilog-multiline-subclass")
+def test_multiline_epilog_subclass_formatter_as_html(build_outcome: str) -> None:
+    ref = (
+        "This epilog\nspans multiple lines.\n\n  this line is indented.\n    and also this.\n\nNow this should be"
+        " a separate paragraph.\n"
+    )
+    assert ref in build_outcome
+
+
 @pytest.mark.sphinx(buildername="text", testroot="complex")
 @pytest.mark.prepare(directive_args=[":usage_width: 100"])
 def test_usage_width_default(build_outcome: str) -> None:


### PR DESCRIPTION
Parsers using a custom formatter that inherits from `RawDescriptionHelpFormatter` (e.g. combining it with `ArgumentDefaultsHelpFormatter`) had their epilog and description rendered as a single collapsed paragraph. The formatter check used exact equality (`==`) instead of `issubclass`, so any subclass silently fell through to the plain-text path.

Preformatted blocks (usage, epilog, description) also rendered with `white-space: pre` in HTML, causing long lines to overflow their container with a horizontal scrollbar. 🔧 A small injected CSS file now applies `pre-wrap` to these blocks so text wraps naturally while preserving newlines and indentation.