### PR TITLE
👷 ci: test against Python 3.15

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - "3.15t"
+          - "3.15"
           - "3.14t"
           - "3.14"
           - "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Documentation",
   "Topic :: Documentation :: Sphinx",
@@ -128,7 +129,7 @@ builtin = "clear,usage,en-GB_to_en-US"
 count = true
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.ty]
 environment.python-version = "3.14"

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.56.1", "tox-uv>=1.35.2" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.14t", "fix", "pkg_meta", "type" ]
+env_list = [ "3.15", "3.14", "3.13", "3.12", "3.11", "3.14t", "3.15t", "fix", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]


### PR DESCRIPTION
Python 3.15 is at 3.15.0b3. This extension reproduces `argparse` output in the rendered docs, so a change to the upstream formatter turns into a diff in every project that uses it. 🐍 Running the suite against the beta gives us a few months to react before 3.15 ships.

I added `3.15` and `3.15t` to the `env` matrix in `check.yaml`, plus the matching `env_list` entries in `tox.toml` so the environments exist locally too. Both follow how 11cf41f declared `3.14`. Neither needs a prerelease flag, since `uv python install` and the tox interpreter discovery pick up the newest available build.

`pyproject.toml` gains the `Programming Language :: Python :: 3.15` classifier, and `[tool.pyproject-fmt] max_supported_python` moves to `3.15`. Without that second entry the hook strips the classifier as newer than the Python it knows, so the two go together. The entry comes back out once pyproject-fmt's own maximum catches up, the way the 3.13 one did. `requires-python` is unchanged and no version is dropped.