### PR TITLE
fix: checks type for nested subparsers

### DIFF
--- a/roots/test-subparsers-storeaction/conf.py
+++ b/roots/test-subparsers-storeaction/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-subparsers-storeaction/index.rst
+++ b/roots/test-subparsers-storeaction/index.rst
@@ -1,0 +1,3 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: make

--- a/roots/test-subparsers-storeaction/parser.py
+++ b/roots/test-subparsers-storeaction/parser.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def make() -> ArgumentParser:
+    parser = ArgumentParser(prog="test")
+
+    sub_parsers = parser.add_subparsers()
+    sub_parser = sub_parsers.add_parser("subparser")
+    sub_parser.add_argument("foo")
+
+    sub_sub_parsers = sub_parser.add_subparsers()
+    sub_sub_parser = sub_sub_parsers.add_parser("child_two")
+    sub_sub_parser.add_argument("--bar")
+
+    return parser

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -149,7 +149,8 @@ class SphinxArgparseCli(SphinxDirective):
 
             if parser._subparsers:  # noqa: SLF001
                 sub_sub_parser: _SubParsersAction[ArgumentParser] = parser._subparsers._group_actions[0]  # type: ignore[assignment]  # noqa: SLF001
-                yield from self._load_sub_parsers(sub_sub_parser)
+                if isinstance(sub_sub_parser, _SubParsersAction):
+                    yield from self._load_sub_parsers(sub_sub_parser)
 
     def _iter_sub_commands(self) -> Iterator[tuple[list[str], str, ArgumentParser]]:
         top_sub_parser = self.parser._subparsers  # noqa: SLF001

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -369,6 +369,13 @@ def test_subparsers(build_outcome: str) -> None:
     assert '<section id="test-no_child-options">' in build_outcome
 
 
+@pytest.mark.sphinx(buildername="html", testroot="subparsers-storeaction")
+def test_subparsers_stoeaction(build_outcome: str) -> None:
+    assert '<section id="test-options">' in build_outcome
+    assert '<section id="test-subparser">' in build_outcome
+    assert '<section id="test-subparser-positional-arguments">' in build_outcome
+
+
 @pytest.mark.sphinx(buildername="text", testroot="bad-module")
 def test_bad_module(app: SphinxTestApp, warning: StringIO) -> None:
     app.build()


### PR DESCRIPTION
this fails:

```
def get_parser_2() -> ArgumentParser:
    parser = ArgumentParser(prog="prog")

    sub_parser = parser.add_subparsers(dest="command")
    command = sub_parser.add_parser("parent")
    command.add_argument("key")

    sub_sub_parser = command.add_subparsers(dest="subcommand")
    subcommand = sub_sub_parser.add_parser("child")
    subcommand.add_argument("--b", action="store_true")

    return parser
```