### PR TITLE
📝 docs: name force_refs_lower correctly in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Allow to add content to directive.
 - Fix Sphinx warnings about parallel reads.
-- Add `force_args_lower` to enable `:ref:` links with mixed-case program names and arguments.
+- Add `force_refs_lower` to enable `:ref:` links with mixed-case program names and arguments.
 - Fix Sphinx smart quotes rewriting `--` to an en dash in `--option` names within descriptions, epilogs, and help text.
 
 ## 1.13.1


### PR DESCRIPTION
The unreleased changelog entry names the directive option `force_args_lower`, while the option `_logic.py` registers and the README documents is `force_refs_lower`. A reader copying the name from the changelog gets an "unknown option" error from docutils. 📝 This corrects the entry to match the code.
