### PR TITLE
🐛 fix: make :hook: intercept parse_intermixed_args()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Register flags and positional arguments as Sphinx program options so the `:option:` role links to them.
 - Leave apostrophes inside words (`don't`, `it's`) alone in help text instead of turning them into broken inline
   literals.
+- Make `:hook:` intercept `parse_intermixed_args()` as well as `parse_args()`.
 
 ## 1.13.1
 

--- a/roots/test-hook-intermixed/conf.py
+++ b/roots/test-hook-intermixed/conf.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+extensions = ["sphinx_argparse_cli"]
+nitpicky = True

--- a/roots/test-hook-intermixed/index.rst
+++ b/roots/test-hook-intermixed/index.rst
@@ -1,0 +1,4 @@
+.. sphinx_argparse_cli::
+  :module: parser
+  :func: main
+  :hook:

--- a/roots/test-hook-intermixed/parser.py
+++ b/roots/test-hook-intermixed/parser.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+
+
+def main() -> None:
+    parser = ArgumentParser(prog="foo", add_help=False)
+    parser.add_argument("--flag", help="a flag")
+    args = parser.parse_intermixed_args()
+    print(args)  # noqa: T201

--- a/src/sphinx_argparse_cli/_logic.py
+++ b/src/sphinx_argparse_cli/_logic.py
@@ -94,14 +94,15 @@ class SphinxArgparseCli(SphinxDirective):
             raise self.error(msg)  # noqa: B904
         parser: ArgumentParser | None = None
         if "hook" in self.options:
-            original_parse_known_args = ArgumentParser.parse_known_args
-            ArgumentParser.parse_known_args = _parse_known_args_hook  # type: ignore[method-assign,assignment]
-            try:
-                parser_creator()
-            except HookError as hooked:
-                parser = hooked.parser
-            finally:
-                ArgumentParser.parse_known_args = original_parse_known_args
+            # parse_intermixed_args bypasses parse_known_args since Python 3.12, so both entry points need the hook
+            with (
+                patch.object(ArgumentParser, "parse_known_args", _parse_known_args_hook),
+                patch.object(ArgumentParser, "parse_known_intermixed_args", _parse_known_args_hook),
+            ):
+                try:
+                    parser_creator()
+                except HookError as hooked:
+                    parser = hooked.parser
         else:
             parser = parser_creator()
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -70,6 +70,24 @@ def test_hook(build_outcome: str) -> None:
     assert build_outcome
 
 
+@pytest.mark.sphinx(buildername="text", testroot="hook-intermixed")
+def test_hook_intermixed(build_outcome: str) -> None:
+    assert (
+        build_outcome
+        == """foo - CLI interface
+*******************
+
+   foo [--flag FLAG]
+
+
+foo options
+===========
+
+* **"--flag"** "FLAG" - a flag
+"""
+    )
+
+
 @pytest.mark.sphinx(buildername="text", testroot="hook-fail")
 def test_hook_fail(app: SphinxTestApp, warning: StringIO) -> None:
     app.build()


### PR DESCRIPTION
A parser factory that ends in `parser.parse_intermixed_args()` defeats the `:hook:` option on Python 3.12 and later. There `parse_known_intermixed_args` calls `_parse_known_args2` instead of `parse_known_args`, so the monkeypatch does not fire, the real parser reads Sphinx's own argv, and the build dies with `error: unrecognized arguments: -b html ...`. 🐛

The hook now covers `parse_known_intermixed_args` as well as `parse_known_args`, both through the same `HookError` raise. Both patches live in one `patch.object` context manager, which also restores the originals when the factory raises something other than `HookError`; the previous save and restore guarded `parse_known_args` alone.

Factories that return the parser or call `parse_args()` behave as before.
