### PR TITLE
📝 docs: explain that help text is reStructuredText

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ For a program named `SampleProgram`:
 If you do not need Sphinx `:ref:` cross-references you can leave this off to keep mixed-case anchors in the HTML output,
 but enabling it later will change existing anchor URLs.
 
+### Write help text as reStructuredText
+
+The directive parses every argument's `help` string as reStructuredText, so inline markup such as a `:ref:` role or
+`**bold**` works. The same applies to characters that carry meaning in reStructuredText: a lone `*` (`match *.py`), a
+trailing `_` (`name_`), backticks, or a trailing `::` produce docutils warnings and fail a build run with `-W`. Escape
+them with a backslash (`match \*.py`) or wrap them in inline literals. Text between matching single quotes, double
+quotes, or braces becomes an inline literal for you, so `pick 'fast' or "slow"` shows `'fast'` and `"slow"` as code.
+
 ### Add extra content after generated docs
 
 Any content nested inside the directive is appended after the generated CLI documentation:


### PR DESCRIPTION
Help strings go through `nested_parse`, so the directive treats them as reStructuredText, and the README does not mention it. A user whose help reads `match *.py files` or `ends with underscore_` gets docutils warnings that fail a `-W` build without an explanation in the docs. 📝

This adds a how-to section stating the behaviour, listing the four characters that trip it in practice (`*`, trailing `_`, backticks, trailing `::`), the backslash escape, and the inline-literal wrapping of quoted or braced text that `load_help_text` performs.
